### PR TITLE
Fixing integration target copy based on azure trial

### DIFF
--- a/roles/migrate_content/tasks/include_process_integration_test_dirs.yaml
+++ b/roles/migrate_content/tasks/include_process_integration_test_dirs.yaml
@@ -8,6 +8,6 @@
 - name: Copy integration targets directory contents when applicable to collection
   copy:
     src: "{{ ansible_source_directory}}/test/integration/targets/{{ item['path']|basename|replace('.py','') }}"
-    dest: "{{ collection_parent }}/test/integration/targets/{{ item['path']|basename|replace('.py','') }}"
+    dest: "{{ collection_parent }}/test/integration/targets/
   when: st['stat']['exists']
 

--- a/roles/migrate_content/tasks/include_process_integration_test_dirs.yaml
+++ b/roles/migrate_content/tasks/include_process_integration_test_dirs.yaml
@@ -8,6 +8,6 @@
 - name: Copy integration targets directory contents when applicable to collection
   copy:
     src: "{{ ansible_source_directory}}/test/integration/targets/{{ item['path']|basename|replace('.py','') }}"
-    dest: "{{ collection_parent }}/test/integration/targets/
+    dest: "{{ collection_parent }}/test/integration/targets/"
   when: st['stat']['exists']
 


### PR DESCRIPTION
In case of azure the integration target copy is creating target folder under target folder.
hence ansible-test fails