### PR TITLE
Use relative module import statements (2nd revision)

### DIFF
--- a/roles/migrate_content/tasks/handle_frimport.yml
+++ b/roles/migrate_content/tasks/handle_frimport.yml
@@ -19,7 +19,7 @@
   set_fact:
     basename: "{{ file['path']|basename }}"
     current: "ansible.module_utils.{{ item['key']  }}"
-    new: ".plugins.module_utils.{{ item['key'] }}"
+    new: "..module_utils.{{ item['key'] }}"
   when: frimports[item['key']] in ['y', 'Y']
 
 - name: "Update the import statements in {{ collection_parent }}/plugins/modules/{{ basename }}"

--- a/roles/migrate_content/tasks/handle_frimport.yml
+++ b/roles/migrate_content/tasks/handle_frimport.yml
@@ -19,7 +19,7 @@
   set_fact:
     basename: "{{ file['path']|basename }}"
     current: "ansible.module_utils.{{ item['key']  }}"
-    new: "ansible_collections.{{ collection_namespace }}.{{ collection_name }}.plugins.module_utils.{{ item['key'] }}"
+    new: ".plugins.module_utils.{{ item['key'] }}"
   when: frimports[item['key']] in ['y', 'Y']
 
 - name: "Update the import statements in {{ collection_parent }}/plugins/modules/{{ basename }}"

--- a/roles/migrate_content/tasks/module_directory_file.yaml
+++ b/roles/migrate_content/tasks/module_directory_file.yaml
@@ -8,7 +8,7 @@
   set_fact:
     basename: "{{ file['path']|basename }}"
     current: "^from ansible.module_utils{{ source_sub_directory|replace('/', '.') }}"
-    new: "from ansible_collections.{{ collection_namespace }}.{{ collection_name }}.plugins.module_utils{{ source_sub_directory|replace('/', '.') }}"
+    new: "from .plugins.module_utils{{ source_sub_directory|replace('/', '.') }}"
 
 - name: "Update the import statements in {{ collection_parent }}/plugins/modules/{{ basename }}"
   replace:

--- a/roles/migrate_content/tasks/module_directory_file.yaml
+++ b/roles/migrate_content/tasks/module_directory_file.yaml
@@ -8,7 +8,7 @@
   set_fact:
     basename: "{{ file['path']|basename }}"
     current: "^from ansible.module_utils{{ source_sub_directory|replace('/', '.') }}"
-    new: "from .plugins.module_utils{{ source_sub_directory|replace('/', '.') }}"
+    new: "from ..module_utils{{ source_sub_directory|replace('/', '.') }}"
 
 - name: "Update the import statements in {{ collection_parent }}/plugins/modules/{{ basename }}"
   replace:

--- a/roles/migrate_content/tasks/module_utils_directory_file.yaml
+++ b/roles/migrate_content/tasks/module_utils_directory_file.yaml
@@ -8,7 +8,7 @@
   set_fact:
     basename: "{{ file['path']|basename }}"
     current: "^from ansible.module_utils{{ source_sub_directory|replace('/', '.') }}"
-    new: "from .plugins.module_utils{{ source_sub_directory|replace('/', '.') }}"
+    new: "from ..module_utils{{ source_sub_directory|replace('/', '.') }}"
 
 - name: "Update the import statements in {{ collection_parent }}/plugins/module_utils/{{ basename }}"
   replace:

--- a/roles/migrate_content/tasks/module_utils_directory_file.yaml
+++ b/roles/migrate_content/tasks/module_utils_directory_file.yaml
@@ -8,7 +8,7 @@
   set_fact:
     basename: "{{ file['path']|basename }}"
     current: "^from ansible.module_utils{{ source_sub_directory|replace('/', '.') }}"
-    new: "from ansible_collections.{{ collection_namespace }}.{{ collection_name }}.plugins.module_utils{{ source_sub_directory|replace('/', '.') }}"
+    new: "from .plugins.module_utils{{ source_sub_directory|replace('/', '.') }}"
 
 - name: "Update the import statements in {{ collection_parent }}/plugins/module_utils/{{ basename }}"
   replace:


### PR DESCRIPTION
Replaces https://github.com/ansible/content_collector/pull/14

I left some details in the Ansible PR https://github.com/ansible/ansible/pull/61196

Tower modules use: https://github.com/AlanCoding/awx/commit/baf1e0a4d482c3fa5be96956da9ceb4357cd600e
^ that's tested, but I'm almost certainly going to re-export these.